### PR TITLE
Add cython < 3 version constraint

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -54,8 +54,8 @@ setup(
             library_dirs=library_dirs,
             include_dirs=include_dirs)
     ],
-    setup_requires=['setuptools>=18', 'cython'],
-    install_requires=['cython'],
+    setup_requires=['setuptools>=18', 'cython<3'],
+    install_requires=['cython<3'],
     author='Dominic Sacre',
     author_email='dominic.sacre@gmx.de',
     maintainer='Eduardo Moguillansky',


### PR DESCRIPTION
The current code is not compatibile with cython >= 3.

Since there's no version restriction, version 3 is installed by default, and fails to build,
this pull-request address the issue by specifying that the cython version must be lower then "3".

This is a "quick fix", a proper solution should be to add support for cython 3.