### PR TITLE
add protocol constants to py interface file

### DIFF
--- a/pyliblo3/_liblo.pyi
+++ b/pyliblo3/_liblo.pyi
@@ -1,4 +1,8 @@
 
+UDP = 1
+UNIX = 2
+TCP = 4
+
 class Callback:
     def __init__(self, func: Callable, user_data: Any): ...
 


### PR DESCRIPTION
All is in the title, add missing constants (UDP, UNIX, TCP) in pyi interface file, this way the IDE knows them.